### PR TITLE
Additional cleanup in preparation for locking down v1.2 schema

### DIFF
--- a/cert_schema/schema/1.2/assertion-1.2.json
+++ b/cert_schema/schema/1.2/assertion-1.2.json
@@ -5,8 +5,32 @@
   "description": "Extends the Open Badges Assertion Schema for certificates on the blockchain",
   "type": "object",
   "definitions": {
+    "JsonLdContext": {
+      "description": "A link to a valid JSON-LD context file, that maps term names to contexts. Blockchain Certificate contexts may also define JSON-schema to validate Blockchain Certificates against. In a Blockchain Certificate Object, this will almost always be a string:uri to a single context file, but might rarely be an array of links or context objects instead. This schema also allows direct mapping of terms to IRIs by using an object as an option within an array.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "array"
+              }
+            ]
+          }
+        }
+      ]
+    },
     "JsonLdType": {
-      "description": "A type or an array of types that the assertion object represents. The first or only item should be 'Assertion', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'Assertion'",
+      "description": "A type or an array of types that the Blockchain Certificate object represents. The first or only item should be 'Assertion', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'Assertion'",
       "oneOf": [
         {
           "type": "string"
@@ -21,6 +45,9 @@
     }
   },
   "properties": {
+    "@context": {
+      "$ref": "#/definitions/JsonLdContext"
+    },
     "type": {
       "$ref": "#/definitions/JsonLdType"
     },
@@ -51,7 +78,6 @@
       "type": "string",
       "pattern": "data:image/png;base64,",
       "description": "Data URI; a base-64 encoded png image of the certificate's image. https://en.wikipedia.org/wiki/Data_URI_scheme"
-
     }
   },
   "required": [

--- a/cert_schema/schema/1.2/blockchain-certificate-1.2.json
+++ b/cert_schema/schema/1.2/blockchain-certificate-1.2.json
@@ -6,7 +6,7 @@
   "type": "object",
   "definitions": {
     "JsonLdContext": {
-      "description": "A link to a valid JSON-LD context file, that maps term names to contexts. Blockchain certificates contexts extend Open Badges contexts, and also define JSON-schema to validate blockchain certificates. This should contain the Blockchain Certificates JSON LD context: https://w3id.org/blockcerts/v1",
+      "description": "A link to a valid JSON-LD context file, that maps term names to contexts. Blockchain Certificate contexts may also define JSON-schema to validate Blockchain Certificates against. In a Blockchain Certificate Object, this will almost always be a string:uri to a single context file, but might rarely be an array of links or context objects instead. This schema also allows direct mapping of terms to IRIs by using an object as an option within an array.",
       "oneOf": [
         {
           "type": "string"
@@ -30,7 +30,7 @@
       ]
     },
     "JsonLdType": {
-      "description": "A type or an array of types that the blockchain certificate object represents. The first or only item should be 'BlockchainCertificate', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'BlockchainCertificate'",
+      "description": "A type or an array of types that the Blockchain Certificate object represents. The first or only item should be 'BlockchainCertificate', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'BlockchainCertificate'",
       "oneOf": [
         {
           "type": "string"
@@ -66,6 +66,7 @@
   },
   "required": [
     "@context",
+    "type",
     "document",
     "receipt"
   ],

--- a/cert_schema/schema/1.2/certificate-1.2.json
+++ b/cert_schema/schema/1.2/certificate-1.2.json
@@ -5,8 +5,32 @@
   "description": "Extends the Open Badges Certificate Schema for certificates on the blockchain",
   "type": "object",
   "definitions": {
+    "JsonLdContext": {
+      "description": "A link to a valid JSON-LD context file, that maps term names to contexts. Blockchain Certificate contexts may also define JSON-schema to validate Blockchain Certificates against. In a Blockchain Certificate Object, this will almost always be a string:uri to a single context file, but might rarely be an array of links or context objects instead. This schema also allows direct mapping of terms to IRIs by using an object as an option within an array.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "array"
+              }
+            ]
+          }
+        }
+      ]
+    },
     "JsonLdType": {
-      "description": "A type or an array of types that the certificate represents. The first or only item should be 'Certificate', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'Certificate'",
+      "description": "A type or an array of types that the Blockchain Certificate object represents. The first or only item should be 'Certificate', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'Certificate'",
       "oneOf": [
         {
           "type": "string"
@@ -24,10 +48,20 @@
     }
   },
   "properties": {
+    "@context": {
+      "$ref": "#/definitions/JsonLdContext"
+    },
+    "type": {
+      "$ref": "#/definitions/JsonLdType"
+    },
     "id": {
       "type": "string",
       "format": "uri",
       "description": "URI link to a JSON that describes the type of certificate. Default format is https://[domain]/criteria/[year]/[month]/[certificate_title].json."
+    },
+    "name": {
+      "type": "string",
+      "description": "Name (or title) of the certificate. V1.2 change: renamed from 'title' to be consistent with OBI schema"
     },
     "description": {
       "type": "string"
@@ -41,14 +75,14 @@
       "type": "string",
       "format": "uri"
     },
+    "issuer": {
+      "$ref": "#/definitions/Issuer"
+    },
     "alignment": {
       "$ref": "https://openbadgespec.org/v1/schema/badgeclass.json#/definitions/AlignmentArray"
     },
     "tags": {
       "$ref": "https://openbadgespec.org/v1/schema/badgeclass.json#/definitions/TagsArray"
-    },
-    "issuer": {
-      "$ref": "#/definitions/Issuer"
     },
     "language": {
       "type": "string",
@@ -58,18 +92,14 @@
     "subtitle": {
       "type": "string",
       "description": "Subtitle of the certificate. V1.2 changes: this type is now string, and this field is optional"
-    },
-    "name": {
-      "type": "string",
-      "description": "Name (or title) of the certificate. V1.2 change: renamed from 'title' to be consistent with OBI schema"
     }
   },
   "required": [
     "id",
-    "image",
     "name",
-    "issuer",
-    "description"
+    "description",
+    "image",
+    "issuer"
   ],
   "additionalProperties": true
 }

--- a/cert_schema/schema/1.2/certificate-1.2.json
+++ b/cert_schema/schema/1.2/certificate-1.2.json
@@ -29,9 +29,6 @@
       "format": "uri",
       "description": "URI link to a JSON that describes the type of certificate. Default format is https://[domain]/criteria/[year]/[month]/[certificate_title].json."
     },
-    "name": {
-      "type": "string"
-    },
     "description": {
       "type": "string"
     },
@@ -62,15 +59,15 @@
       "type": "string",
       "description": "Subtitle of the certificate. V1.2 changes: this type is now string, and this field is optional"
     },
-    "title": {
+    "name": {
       "type": "string",
-      "description": "Title of the certificate. Note: this is called 'name' in the OBI schema"
+      "description": "Name (or title) of the certificate. V1.2 change: renamed from 'title' to be consistent with OBI schema"
     }
   },
   "required": [
     "id",
     "image",
-    "title",
+    "name",
     "issuer",
     "description"
   ],

--- a/cert_schema/schema/1.2/certificate-document-1.2.json
+++ b/cert_schema/schema/1.2/certificate-document-1.2.json
@@ -5,8 +5,32 @@
   "description": "The complete certificate document, including the assertion, certificate, and issuer. Doesn't include the blockchain receipt. This part is hashed and placed on the blockchain",
   "type": "object",
   "definitions": {
+    "JsonLdContext": {
+      "description": "A link to a valid JSON-LD context file, that maps term names to contexts. Blockchain Certificate contexts may also define JSON-schema to validate Blockchain Certificates against. In a Blockchain Certificate Object, this will almost always be a string:uri to a single context file, but might rarely be an array of links or context objects instead. This schema also allows direct mapping of terms to IRIs by using an object as an option within an array.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "array"
+              }
+            ]
+          }
+        }
+      ]
+    },
     "JsonLdType": {
-      "description": "A type or an array of types that the document object represents. The first or only item should be 'CertificateDocument', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'CertificateDocument'",
+      "description": "A type or an array of types that the Blockchain Certificate object represents. The first or only item should be 'CertificateDocument', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'CertificateDocument'",
       "oneOf": [
         {
           "type": "string"
@@ -100,9 +124,11 @@
       ],
       "additionalProperties": true
     }
-
   },
   "properties": {
+    "@context": {
+      "$ref": "#/definitions/JsonLdContext"
+    },
     "type": {
       "$ref": "#/definitions/JsonLdType"
     },
@@ -120,6 +146,7 @@
     }
   },
   "required": [
+    "type",
     "certificate",
     "assertion",
     "verify",

--- a/cert_schema/schema/1.2/certificate-document-1.2.json
+++ b/cert_schema/schema/1.2/certificate-document-1.2.json
@@ -77,9 +77,13 @@
           "type": "string",
           "description": "per the OBI standard, if the recipient identity is hashed, then this should contain the string used to salt the hash"
         },
-        "pubkey": {
+        "publicKey": {
           "type": "string",
-          "description": "Bitcoin address (compressed public key, usually 24 characters) of the recipient."
+          "description": "Bitcoin address (compressed public key, usually 24 characters) of the recipient. V1.2 change: renamed from pubkey"
+        },
+        "revocationKey": {
+          "type": "string",
+          "description": "Issuer revocation key for the recipient, optional. Bitcoin address (compressed public key, usually 24 characters) of the recipient."
         },
         "givenName": {
           "type": "string",
@@ -90,9 +94,8 @@
         "type",
         "familyName",
         "identity",
-        "type",
         "hashed",
-        "pubkey",
+        "publicKey",
         "givenName"
       ],
       "additionalProperties": true

--- a/cert_schema/schema/1.2/context.json
+++ b/cert_schema/schema/1.2/context.json
@@ -52,8 +52,11 @@
         "@id": "bc:receipt",
         "@type": "@id"
       },
-      "pubkey": {
-        "@id": "bc:pubkey"
+      "publicKey": {
+        "@id": "bc:publicKey"
+      },
+      "revocationKey": {
+        "@id": "bc:revocationKey"
       },
       "image:signature": {
         "@id": "bc:image:signature"
@@ -75,17 +78,53 @@
         "@id": "bc:attribute-signed"
       },
       "ECDSA(secp256k1)": "bc:SignedBadge",
-      "name": {
-        "@id": "schema:name"
-      },
-      "uid": {
-        "@id": "bc:uid"
-      },
       "subtitle": {
         "@id": "bc:subtitle"
       },
-      "title": {
-        "@id": "bc:title"
+      "email": "schema:email",
+      "hashed": {
+        "@id": "obi:hashed",
+        "@type": "xsd:boolean"
+      },
+      "image": {
+        "@id": "schema:image",
+        "@type": "@id"
+      },
+      "salt": {
+        "@id": "obi:salt"
+      },
+      "identity": {
+        "@id": "obi:identityHash"
+      },
+      "issuedOn": {
+        "@id": "obi:issueDate",
+        "@type": "xsd:dateTime"
+      },
+      "expires": {
+        "@id": "sec:expiration",
+        "@type": "xsd:dateTime"
+      },
+      "evidence": {
+        "@id": "obi:evidence",
+        "@type": "@id"
+      },
+      "criteria": {
+        "@id": "obi:criteria",
+        "@type": "@id"
+      },
+      "tags": {
+        "@id": "schema:keywords"
+      },
+      "alignment": {
+        "@id": "obi:alignment",
+        "@type": "@id"
+      },
+      "revocationList": {
+        "@id": "obi:revocationList",
+        "@type": "@id"
+      },
+      "name": {
+        "@id": "schema:name"
       },
       "description": {
         "@id": "schema:description"
@@ -94,25 +133,15 @@
         "@id": "schema:url",
         "@type": "@id"
       },
-      "email": "schema:email",
-      "hashed": "obi:hashed",
-      "image": "obi:image",
-      "salt": "obi:salt",
-      "identity": "obi:identity",
-      "issuedOn": "obi:issuedOn",
-      "expires": "obi:expires",
-      "evidence": "obi:evidence",
-      "criteria": "obi:criteria",
-      "tags": "obi:tags",
-      "alignment": "obi:alignment",
+      "uid": {
+        "@id": "obi:uid"
+      },
       "revocationList": "obi:revocationList",
       "TypeValidation": "obi:TypeValidation",
       "FrameValidation": "obi:FrameValidation",
-
       "validatesType": "obi:validatesType",
       "validationSchema": "obi:validationSchema",
       "validationFrame": "obi:validationFrame",
-
       "ChainpointSHA224v2": "cp:ChainpointSHA224v2",
       "ChainpointSHA256v2": "cp:ChainpointSHA256v2",
       "ChainpointSHA384v2": "cp:ChainpointSHA384v2",
@@ -121,13 +150,11 @@
       "ChainpointSHA3-256v2": "cp:ChainpointSHA3-256v2",
       "ChainpointSHA3-384v2": "cp:ChainpointSHA3-384v2",
       "ChainpointSHA3-512v2": "cp:ChainpointSHA3-512v2",
-
       "BTCOpReturn": "cp:BTCOpReturn",
       "targetHash": "cp:targetHash",
       "merkleRoot": "cp:merkleRoot",
       "proof": "cp:proof",
-      "anchors":  "cp:anchors",
-
+      "anchors": "cp:anchors",
       "sourceId": "cp:sourceId",
       "right": "cp:right",
       "left": "cp:left"

--- a/cert_schema/schema/1.2/issuer-1.2.json
+++ b/cert_schema/schema/1.2/issuer-1.2.json
@@ -5,8 +5,32 @@
   "description": "Extends the Open Badges Issuer Schema for certificates on the blockchain",
   "type": "object",
   "definitions": {
+    "JsonLdContext": {
+      "description": "A link to a valid JSON-LD context file, that maps term names to contexts. Blockchain Certificate contexts may also define JSON-schema to validate Blockchain Certificates against. In a Blockchain Certificate Object, this will almost always be a string:uri to a single context file, but might rarely be an array of links or context objects instead. This schema also allows direct mapping of terms to IRIs by using an object as an option within an array.",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              },
+              {
+                "type": "array"
+              }
+            ]
+          }
+        }
+      ]
+    },
     "JsonLdType": {
-      "description": "A type or an array of types that the issuer object represents. The first or only item should be 'Issuer', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'Issuer'",
+      "description": "A type or an array of types that the Blockchain Certificate object represents. The first or only item should be 'Issuer', and any others should each be an IRI (usually a URL) corresponding to a definition of the type itself. In almost all cases, there will be only one type: 'Issuer'",
       "oneOf": [
         {
           "type": "string"
@@ -33,13 +57,19 @@
     }
   },
   "properties": {
+    "@context": {
+      "$ref": "#/definitions/JsonLdContext"
+    },
+    "type": {
+      "$ref": "#/definitions/JsonLdType"
+    },
     "id": {
       "type": "string",
       "format": "uri",
       "description": "Link to a JSON that details the issuer's issuing and recovation keys. Default is https://[domain]/issuer/[org_abbr]-issuer.json. Included for (near) backward compatibility with open badges specification 1.1"
     },
-    "image" : {
-     "$ref": "#/definitions/BCBadgeImage"
+    "image": {
+      "$ref": "#/definitions/BCBadgeImage"
     },
     "name": {
       "description": "Human-readable name of the issuing entity",

--- a/examples/1.2/sample_signed_cert-1.2.json
+++ b/examples/1.2/sample_signed_cert-1.2.json
@@ -25,14 +25,14 @@
         "url": "http://www.theissuer.edu"
       },
       "subtitle": "2016",
-      "title": "Certificate title"
+      "name": "Certificate name"
     },
     "recipient": {
       "familyName": "RecipientLastName",
       "givenName": "RecipientFirstName",
       "hashed": false,
       "identity": "recipient@domain.com",
-      "pubkey": "1GCrFRozNVWCqTreV7ZoXudiotknoJeXaz",
+      "publicKey": "1GCrFRozNVWCqTreV7ZoXudiotknoJeXaz",
       "type": "email"
     },
     "signature": "IAhahreb77hgM9khBcWCSfwq0Qal/bzU9AzBSUMEDErTdExBRHsBH2dDmBa1NvR38wVGn70SPEglI0VIvUFc2AI=",

--- a/examples/1.2/sample_unsigned_cert-1.2.json
+++ b/examples/1.2/sample_unsigned_cert-1.2.json
@@ -1,10 +1,10 @@
 {
   "@context": "http://www.blockcerts.org/schema/1.2/context.json",
-  "@type": "BlockchainCertificate",
+  "type": "BlockchainCertificate",
   "document": {
-    "@type": "CertificateDocument",
+    "type": "CertificateDocument",
     "assertion": {
-      "@type": "Assertion",
+      "type": "Assertion",
       "evidence": "",
       "id": "http://www.theissuer.edu/fb9e6259-f3ee-438a-b98f-a24f54187af8",
       "image:signature": "data:image/png;base64,",
@@ -12,12 +12,12 @@
       "uid": "fb9e6259-f3ee-438a-b98f-a24f54187af8"
     },
     "certificate": {
-      "@type": "Certificate",
+      "type": "Certificate",
       "description": "Certificate description",
       "id": "https://www.theissuer.edu/criteria/2016/05/certificate-type.json",
       "image": "data:image/png;base64,",
       "issuer": {
-        "@type": "Issuer",
+        "type": "Issuer",
         "email": "issuer@theissuer.edu",
         "id": "https://www.theissuer.edu/issuer/the-issuer.json",
         "image": "data:image/png;base64,",
@@ -25,19 +25,17 @@
         "url": "http://www.theissuer.edu"
       },
       "subtitle": "2016",
-      "title": "Certificate title"
+      "name": "Certificate name"
     },
     "recipient": {
-      "@type": "Recipient",
       "familyName": "RecipientLastName",
       "givenName": "RecipientFirstName",
       "hashed": false,
       "identity": "recipient@domain.com",
-      "pubkey": "1GCrFRozNVWCqTreV7ZoXudiotknoJeXaz",
+      "publicKey": "1GCrFRozNVWCqTreV7ZoXudiotknoJeXaz",
       "type": "email"
     },
     "verify": {
-      "@type": "VerificationObject",
       "attribute-signed": "uid",
       "signer": "https://www.theissuer.edu/keys/signing-public-key.asc",
       "type": "ECDSA(secp256k1)"


### PR DESCRIPTION
- Make JSON LD context and type descriptions self-consistent, and consistent with OBI
- Schema reordering for OBI schema consistency (doesn't affect behavior, just for readability)
- Collapse obi JSON LD context refs -- while the nquads are the same either way, the expansion is clearer this way
- 2 renames:
  - title -> name for consistency with OBI. We should go ahead and do this since we'll be updating all samples
  - pubkey -> publicKey: self consistency eyesore
