### PR TITLE
Fix chains

### DIFF
--- a/cert_schema/__init__.py
+++ b/cert_schema/__init__.py
@@ -20,48 +20,112 @@ class BlockcertVersion(Enum):
     V2 = 2
 
 
-class Chain(Enum):
-    mainnet = 0, 'BTC'
-    testnet = 1, 'XTN'
-    regtest = 2, 'REG'
-    # Made up code; hopefully it will never cause a conflict =/
-    mocknet = 3, 'MOK'
-
-    def __new__(cls, enum_value, netcode):
+class BlockchainType(Enum):
+    bitcoin = 0, 'BTCOpReturn'
+    ethereum = 1, 'ETHData'
+    mock = 2, 'Mock'
+    
+    def __new__(cls, enum_value,  external_display_value):
         obj = object.__new__(cls)
         obj._value_ = enum_value
-        obj.netcode = netcode
+        obj.external_display_value = external_display_value
+        return obj
+
+
+class Chain(Enum):
+    bitcoin_mainnet = 0, BlockchainType.bitcoin, 'bitcoinMainnet'
+    bitcoin_testnet = 1, BlockchainType.bitcoin, 'bitcoinTestnet'
+    bitcoin_regtest = 2, BlockchainType.bitcoin, 'bitcoinRegtest'
+    mockchain = 3, BlockchainType.mock, 'mockchain'
+    ethereum_mainnet = 4, BlockchainType.ethereum, 'ethereumMainnet'
+    ethereum_ropsten = 5, BlockchainType.ethereum, 'ethereumRopsten'
+    ethereum_testnet = 6, BlockchainType.ethereum, 'ethereumTestnet'
+
+    def __new__(cls, enum_value, blockchain_type, external_display_value):
+        obj = object.__new__(cls)
+        obj._value_ = enum_value
+        obj.blockchain_type = blockchain_type
+        obj.external_display_value = external_display_value
         return obj
 
     @staticmethod
     def parse_from_chain(chain_string):
-        if chain_string == 'mainnet':
-            return Chain.mainnet
-        elif chain_string == 'testnet':
-            return Chain.testnet
-        elif chain_string == 'regtest':
-            return Chain.regtest
-        elif chain_string == 'mocknet':
-            return Chain.mocknet
+        if chain_string == 'bitcoin_mainnet':
+            return Chain.bitcoin_mainnet
+        elif chain_string == 'bitcoin_testnet':
+            return Chain.bitcoin_testnet
+        elif chain_string == 'bitcoin_regtest':
+            return Chain.bitcoin_regtest
+        elif chain_string == 'mockchain':
+            return Chain.mockchain
+        elif chain_string == 'ethereum_mainnet':
+            return Chain.ethereum_mainnet
+        elif chain_string == 'ethereum_ropsten':
+            return Chain.ethereum_ropsten
+        elif chain_string == 'ethereum_testnet':
+            return Chain.ethereum_testnet
         else:
             raise UnknownChainError(chain_string)
 
     @staticmethod
-    def parse_from_netcode(netcode_string):
-        if netcode_string == 'BTC':
-            return Chain.mainnet
-        elif netcode_string == 'XTN':
-            return Chain.testnet
-        elif netcode_string == 'REG':
-            return Chain.regtest
-        elif netcode_string == 'MOK':
-            return Chain.mocknet
+    def parse_from_external_display_value(external_display_value):
+        if external_display_value == 'bitcoinMainnet':
+            return Chain.bitcoin_mainnet
+        elif external_display_value == 'bitcoinTestnet':
+            return Chain.bitcoin_testnet
+        elif external_display_value == 'bitcoinRegtest':
+            return Chain.bitcoin_regtest
+        elif external_display_value == 'mockchain':
+            return Chain.mockchain
+        elif external_display_value == 'ethereumMainnet':
+            return Chain.ethereum_mainnet
+        elif external_display_value == 'ethereumRopsten':
+            return Chain.ethereum_ropsten
+        elif external_display_value == 'ethereumTestnet':
+            return Chain.ethereum_testnet
         else:
-            raise UnknownChainError(netcode_string)
+            raise UnknownChainError(external_display_value)
+
+def chain_to_bitcoin_netcode(chain):
+    if chain == Chain.bitcoin_mainnet:
+        return 'BTC'
+    elif chain.blockchain_type == BlockchainType.bitcoin:
+        return 'XTN'
+    else:
+        message = 'This chain cannot be converted to a bitcoin netcode; chain='
+        if chain:
+            message += chain.name
+        else:
+            message += '<NULL>'
+        raise UnknownChainError(message)
 
 
-def is_mainnet_address(address):
-    return address.startswith('1')
+def to_source_id(txid, chain):
+    if chain == Chain.mainnet or Chain.testnet:
+        return txid
+    else:
+        return 'This has not been issued on a blockchain and is for testing only'
+
+
+def to_anchor_type(chain):
+    """
+    Return the anchor type to include in the Blockcert signature. In next version of Blockcerts schema we will be able
+    to write XTNOpReturn for testnet
+    :param chain:
+    :return:
+    """
+    if chain == Chain.mainnet or chain == Chain.testnet:
+        return 'BTCOpReturn'
+    # non-standard
+    elif chain == Chain.regtest:
+        return 'REGOpReturn'
+    # non-standard
+    elif chain == Chain.mockchain:
+        return 'MockOpReturn'
+
+
+def is_bitcoin_mainnet_address(address):
+    return address.startswith('1') or address.startswith(PUBKEY_PREFIX + '1')
 
 
 class BlockcertValidationError(Exception):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(os.path.join(here, 'README.md')) as fp:
 
 setup(
     name='cert-schema',
-    version='2.0.4',
+    version='2.0.5',
     description='tools for working with blockchain certificates',
     author='info@blockcerts.org',
     tests_require=['tox'],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,44 +5,114 @@ from cert_schema import *
 
 class TestInit(unittest.TestCase):
     def test_is_mainnet_address_true(self):
-        is_mainnet = is_mainnet_address('1HB5XMLmzFVj8ALj6mfBsbifRoD4miY36v')
+        is_mainnet = is_bitcoin_mainnet_address('1HB5XMLmzFVj8ALj6mfBsbifRoD4miY36v')
         self.assertTrue(is_mainnet)
 
     def test_is_mainnet_address_false(self):
-        is_mainnet = is_mainnet_address('mjgZHpD1AzEixLgcnncod5df6CntYK4Jpi')
+        is_mainnet = is_bitcoin_mainnet_address('mjgZHpD1AzEixLgcnncod5df6CntYK4Jpi')
         self.assertFalse(is_mainnet)
 
-    def test_parse_chain_from_chain_string_mainnet(self):
-        chain = Chain.parse_from_chain('mainnet')
-        self.assertEquals(chain, Chain.mainnet)
+    def test_blockchain_display_value_bitcoin(self):
+        chain = BlockchainType.bitcoin
+        self.assertEquals(chain.external_display_value, 'BTCOpReturn')
 
-    def test_parse_chain_from_chain_string_testnet(self):
-        chain = Chain.parse_from_chain('testnet')
-        self.assertEquals(chain, Chain.testnet)
+    def test_blockchain_display_value_ethereum(self):
+        chain = BlockchainType.ethereum
+        self.assertEquals(chain.external_display_value, 'ETHData')
 
-    def test_parse_chain_from_chain_string_regtest(self):
-        chain = Chain.parse_from_chain('regtest')
-        self.assertEquals(chain, Chain.regtest)
+    def test_blockchain_display_value_mock(self):
+        chain = BlockchainType.mock
+        self.assertEquals(chain.external_display_value, 'Mock')
 
-    def test_parse_chain_from_chain_string_mocknet(self):
-        chain = Chain.parse_from_chain('mocknet')
-        self.assertEquals(chain, Chain.mocknet)
+    def test_parse_from_chain_string_bitcoin_mainnet(self):
+        chain = Chain.parse_from_chain('bitcoin_mainnet')
+        self.assertEquals(chain, Chain.bitcoin_mainnet)
 
-    def test_parse_chain_from_netcode_mainnet(self):
-        chain = Chain.parse_from_netcode('BTC')
-        self.assertEquals(chain, Chain.mainnet)
+    def test_parse_from_chain_string_bitcoin_testnet(self):
+        chain = Chain.parse_from_chain('bitcoin_testnet')
+        self.assertEquals(chain, Chain.bitcoin_testnet)
 
-    def test_parse_chain_from_chain_testnet(self):
-        chain = Chain.parse_from_netcode('XTN')
-        self.assertEquals(chain, Chain.testnet)
+    def test_parse_from_chain_string_bitcoin_regtest(self):
+        chain = Chain.parse_from_chain('bitcoin_regtest')
+        self.assertEquals(chain, Chain.bitcoin_regtest)
 
-    def test_parse_chain_from_chain_regtest(self):
-        chain = Chain.parse_from_netcode('REG')
-        self.assertEquals(chain, Chain.regtest)
+    def test_parse_from_chain_string_ethereum_mainnet(self):
+        chain = Chain.parse_from_chain('ethereum_mainnet')
+        self.assertEquals(chain, Chain.ethereum_mainnet)
 
-    def test_parse_chain_from_chain_testnet(self):
-        chain = Chain.parse_from_netcode('MOK')
-        self.assertEquals(chain, Chain.mocknet)
+    def test_parse_from_chain_string_ethereum_testnet(self):
+        chain = Chain.parse_from_chain('ethereum_testnet')
+        self.assertEquals(chain, Chain.ethereum_testnet)
+
+    def test_parse_from_chain_string_ethereum_ropsten(self):
+        chain = Chain.parse_from_chain('ethereum_ropsten')
+        self.assertEquals(chain, Chain.ethereum_ropsten)
+
+    def test_parse_from_chain_string_mockchain(self):
+        chain = Chain.parse_from_chain('mockchain')
+        self.assertEquals(chain, Chain.mockchain)
+
+    def test_parse_from_external_display_value_bitcoin_mainnet(self):
+        chain = Chain.parse_from_external_display_value('bitcoinMainnet')
+        self.assertEquals(chain, Chain.bitcoin_mainnet)
+
+    def test_parse_from_external_display_value_bitcoin_testnet(self):
+        chain = Chain.parse_from_external_display_value('bitcoinTestnet')
+        self.assertEquals(chain, Chain.bitcoin_testnet)
+
+    def test_parse_from_external_display_value_bitcoin_regtest(self):
+        chain = Chain.parse_from_external_display_value('bitcoinRegtest')
+        self.assertEquals(chain, Chain.bitcoin_regtest)
+
+    def test_parse_from_external_display_value_ethereum_mainnet(self):
+        chain = Chain.parse_from_external_display_value('ethereumMainnet')
+        self.assertEquals(chain, Chain.ethereum_mainnet)
+
+    def test_parse_from_external_display_value_ethereum_testnet(self):
+        chain = Chain.parse_from_external_display_value('ethereumTestnet')
+        self.assertEquals(chain, Chain.ethereum_testnet)
+
+    def test_parse_from_external_display_value_ethereum_ropsten(self):
+        chain = Chain.parse_from_external_display_value('ethereumRopsten')
+        self.assertEquals(chain, Chain.ethereum_ropsten)
+
+    def test_parse_from_external_display_value_mockchain(self):
+        chain = Chain.parse_from_external_display_value('mockchain')
+        self.assertEquals(chain, Chain.mockchain)
+
+    def test_bitcoin_chain_to_netcode_bitcoin_mainnet(self):
+        netcode = chain_to_bitcoin_netcode(Chain.bitcoin_mainnet)
+        self.assertEquals(netcode, 'BTC')
+
+    def test_bitcoin_chain_to_netcode_bitcoin_testnet(self):
+        netcode = chain_to_bitcoin_netcode(Chain.bitcoin_testnet)
+        self.assertEquals(netcode, 'XTN')
+
+    def test_bitcoin_chain_to_netcode_bitcoin_testnet(self):
+        netcode = chain_to_bitcoin_netcode(Chain.bitcoin_regtest)
+        self.assertEquals(netcode, 'XTN')
+
+    def test_bitcoin_chain_to_netcode_mocknet(self):
+        """
+        This should fail. Assert that we get an UnknownChainError
+        :return:
+        """
+        try:
+            chain_to_bitcoin_netcode(Chain.mockchain)
+            self.assertTrue(False)
+        except UnknownChainError:
+            self.assertTrue(True)
+
+    def test_bitcoin_chain_to_netcode_ethereum_mainnet(self):
+        """
+        This should fail. Assert that we get an UnknownChainError
+        :return:
+        """
+        try:
+            chain_to_bitcoin_netcode(Chain.ethereum_mainnet)
+            self.assertTrue(False)
+        except UnknownChainError:
+            self.assertTrue(True)
 
     def test_blockcerts_versions_v2(self):
         v2_alpha = BlockcertVersion.V2_ALPHA

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -6,6 +6,7 @@ from cert_schema import helpers
 from cert_schema import model
 from cert_schema.model import ProofType, parse_date
 from cert_schema.model import SignatureType
+from cert_schema import Chain
 
 
 class TestModel(unittest.TestCase):
@@ -49,10 +50,11 @@ class TestModel(unittest.TestCase):
             self.assertEquals(certificate_model.signatures[0].signature_type, SignatureType.signed_content)
             self.assertEquals(certificate_model.signatures[1].signature_type, SignatureType.signed_transaction)
             self.assertIsNone(certificate_model.signatures[1].merkle_proof)
+            self.assertEquals(certificate_model.chain, Chain.bitcoin_testnet)
 
     def test_to_certificate_model_v1_2(self):
         """
-        Note this is a mainnet certificate with different uid
+        Note this is a bitcoin_mainnet certificate with different uid
         :return:
         """
         with open('data/1.2/609c2989-275f-4f4c-ab02-b245cfb09017.json', 'rb') as cert_file:
@@ -75,6 +77,7 @@ class TestModel(unittest.TestCase):
             self.assertEquals(certificate_model.recipient_public_key, '1AAGG6jirbu9XwikFpkHokbbiYpjVtFe1G')
             self.assertEquals(certificate_model.issued_on, parse_date('2016-10-03 00:00:00+00:00'))
             self.assertIsNotNone(certificate_model.signature_image[0].image)
+            self.assertEquals(certificate_model.chain, Chain.bitcoin_mainnet)
 
     def test_to_proof(self):
         with open('data/1.2/receipt.json') as receipt_file:
@@ -113,6 +116,7 @@ class TestModel(unittest.TestCase):
             self.assertEquals(certificate_model.issuer.name, 'Issuer Institution Name')
             self.assertEquals(certificate_model.recipient_public_key, 'mkwntSiQmc14H65YxwckLenxY3DsEpvFbe')
             self.assertEquals(certificate_model.issued_on, parse_date('2017-05-01 00:00:00+00:00'))
+            self.assertEquals(certificate_model.chain, Chain.bitcoin_testnet)
 
     def test_to_certificate_model_v2(self):
         with open('data/2.0/bbba8553-8ec1-445f-82c9-a57251dd731c.json', 'rb') as cert_file:
@@ -133,6 +137,7 @@ class TestModel(unittest.TestCase):
             self.assertEquals(certificate_model.issuer.name, 'University of Learning')
             self.assertEquals(certificate_model.recipient_public_key, 'mtr98kany9G1XYNU74pRnfBQmaCg2FZLmc')
             self.assertEquals(certificate_model.issued_on, parse_date('2017-06-29T14:58:57.461422+00:00'))
+            self.assertEquals(certificate_model.chain, Chain.bitcoin_testnet)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Per discussion with @msporny, instead of using signature anchor `type` (JSON-LD `@type`) to encode different chains like testnet, regtest, etc, we should keep these fixed and add a new field for this distinction.

The only user-facing part is the "external" values, which will be embedded and parsed from the Blockcerts signatures. The rest is for library use.

The new field is `chain`. This is new and non-normative. The specific values may change in the future, but would correspond to a new Blockcerts version.